### PR TITLE
Aesthetic pricing during auction

### DIFF
--- a/contracts/EditionsAuction.sol
+++ b/contracts/EditionsAuction.sol
@@ -377,7 +377,7 @@ contract EditionsAuction is IEditionsAuction, ReentrancyGuard{
     }
 
     // return startPrice if auction hasn't started yet
-    if(block.timestamp < auctions[auctionId].startTimestamp.add(auctions[auctionId].step.time)){
+    if(block.timestamp <= auctions[auctionId].startTimestamp.add(auctions[auctionId].step.time)){
       return auctions[auctionId].startPrice;
     }
 
@@ -387,7 +387,56 @@ contract EditionsAuction is IEditionsAuction, ReentrancyGuard{
     uint256 dropNum = timeSinceStart.sub(remainder).div(auctions[auctionId].step.time);
 
     // transalte -1 so endPrice is after auction.duration
-    return auctions[auctionId].startPrice.sub(auctions[auctionId].step.price.mul(dropNum - 1));
+    uint256 price = auctions[auctionId].startPrice.sub(auctions[auctionId].step.price.mul(dropNum - 1));
+
+    return _floor(
+      price,
+      _unit10(auctions[auctionId].step.price, 2)
+    );
+  }
+
+  /**
+   * @dev floors number to nearest specified unit
+   * @param value number to floor
+   * @param unit number specififying the smallest uint to floor to
+   * @return result number floored to nearest unit
+  */
+  function _floor(uint256 value, uint256 unit) internal pure returns (uint256){
+    uint256 remainder = value.mod(unit);
+    return value - remainder;
+  }
+
+  /** @dev calculates exponent from given value number of digits minus the offset
+   * and returns 10 to the power of the resulting exponent
+   * @param value the number of which the exponent is calculated from
+   * @param exponentOffset the number to offset the resulting exponent
+   * @return result 10 to the power of calculated exponent
+   */
+  function _unit10(uint256 value, uint256 exponentOffset) internal pure returns (uint256){
+    uint256 exponent = _getDigits(value);
+    if(exponent < exponentOffset){
+      // HACK: just make zero for now, will need to account for possible negative overflow
+      exponentOffset = 0;
+    }
+
+    return 10**(exponent - exponentOffset);
+  }
+
+   /**
+    * @dev gets number of digits of a number
+    * @param value number to count digits of
+    * @return digits number of digits in value
+    */
+  function _getDigits(uint256 value) internal pure returns (uint256) {
+      if (value == 0) {
+          return 0;
+      }
+      uint256 digits;
+      while (value != 0) {
+          digits++;
+          value /= 10;
+      }
+      return digits;
   }
   // TODO: endAuction end everything if sold out remove form auctions mapping?
 }


### PR DESCRIPTION
resolves #18

during auction the prices are floored to the nearest "power of 10" unit based on the size of the step price.

The start price and end price are left as is.

**For example:**
An auction with a step price of `3.378186666666666666` :nauseated_face: 
The first drop price might look like `6.856373333333333334` :vomiting_face:  
But is quantized to `6.8` :relieved:

**examples of step prices and resulting floor unit:**
step price of `0.1` the drop price will be floored to nearest `0.01`
step price of `500.00` the drop price will be floored to nearest `10.00`
step price of `23.456789` the drop price will be floored to nearest `1.00`

gas benchmark
![Screenshot from 2022-06-07 11-49-07](https://user-images.githubusercontent.com/47055562/172806249-dd9c1c78-ae61-4966-8e04-b10583d63a34.png)

resulting gas changes
![Screenshot from 2022-06-09 09-53-14](https://user-images.githubusercontent.com/47055562/172807069-a1cbd476-492a-42be-bda8-5bc140818013.png)

