### PR TITLE
Ending auctions

### DIFF
--- a/contracts/EditionsAuction.sol
+++ b/contracts/EditionsAuction.sol
@@ -213,6 +213,37 @@ contract EditionsAuction is IEditionsAuction, Utils, SeededPurchaseHandler, Stan
   }
 
   /**
+   * @notice allows the creator to trigger a collector only give away once an auction is over
+   * @dev sets auction collectorGiveAway to giveAway and emits an CollectorGiveAwayUpdated event
+   * @param auctionId the id of the auction
+   * @param giveAway the creators giveAway decision
+   */
+  function setCollectorGiveAway(
+    uint256 auctionId,
+    bool giveAway
+  ) external
+    override
+    auctionExists(auctionId)
+  {
+    require(
+      msg.sender == auctions[auctionId].creator,
+      "Must be creator"
+    );
+    require(
+      block.timestamp > auctions[auctionId].startTimestamp.add(auctions[auctionId].duration),
+      "Auction is not over"
+    );
+
+    auctions[auctionId].collectorGiveAway = giveAway;
+
+    emit CollectorGiveAwayUpdated(
+      auctionId,
+      auctions[auctionId].edition.id,
+      giveAway
+    );
+  }
+
+  /**
    * @notice gets the current sale price of an auction
    * @dev calculates the price based on the block.timestamp
    * @param auctionId the id of the auction

--- a/contracts/EditionsAuction.sol
+++ b/contracts/EditionsAuction.sol
@@ -20,7 +20,7 @@ import {Utils} from "./Utils.sol";
 /**
  * @title An open dutch auction house, for initial drops of limited edition nft contracts.
  */
-contract EditionsAuction is IEditionsAuction, AuctionUtils, SeededPurchaseHandler, StandardPurchaseHandler, ReentrancyGuard{
+contract EditionsAuction is IEditionsAuction, Utils, SeededPurchaseHandler, StandardPurchaseHandler, ReentrancyGuard{
   using SafeMath for uint256;
   using Counters for Counters.Counter;
 

--- a/contracts/EditionsAuction.sol
+++ b/contracts/EditionsAuction.sol
@@ -168,8 +168,6 @@ contract EditionsAuction is IEditionsAuction, ReentrancyGuard{
     return auctionId;
   }
 
-
-
   function _calcStep (
     uint256 duration,
     uint256 startPrice,
@@ -381,6 +379,23 @@ contract EditionsAuction is IEditionsAuction, ReentrancyGuard{
     );
 
     _cancelAuction(auctionId);
+  }
+
+  function endAuction(uint256 auctionId) external override {
+    require(
+      msg.sender == auctions[auctionId].creator || msg.sender == auctions[auctionId].curator,
+      "Must be creator or curator"
+    );
+
+    // check the auction has run it's full duration
+    require(
+      block.timestamp > auctions[auctionId].startTimestamp + auctions[auctionId].duration,
+      "Auction is not over"
+    );
+
+    emit AuctionEnded(auctionId, auctions[auctionId].edition.id);
+    hasActiveAuction[auctions[auctionId].edition.id] = false;
+    delete auctions[auctionId];
   }
 
   /**

--- a/contracts/EditionsAuction.sol
+++ b/contracts/EditionsAuction.sol
@@ -15,7 +15,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 import {IEditionSingleMintable} from "./editions-nft/IEditionSingleMintable.sol";
 import {ISeededEditionSingleMintable, MintData} from "./editions-nft/ISeededEditionSingleMintable.sol";
-import {IEditionsAuction, Edition, Step, Implementation, ERC721} from "./IEditionsAuction.sol";
+import {IEditionsAuction, Edition, Implementation, ERC721} from "./IEditionsAuction.sol";
 
 /**
  * @title An open dutch auction house, for initial drops of limited edition nft contracts.

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -64,6 +64,12 @@ interface IEditionsAuction {
     bool approved
   );
 
+  event CollectorGiveAwayUpdated(
+    uint256 auctionId,
+    address editionContract,
+    bool giveAway
+  );
+
   event AuctionCanceled(
     uint256 auctionId,
     address editionContract
@@ -87,6 +93,8 @@ interface IEditionsAuction {
   ) external returns (uint256);
 
   function setAuctionApproval(uint auctionId, bool approved) external;
+
+  function setCollectorGiveAway(uint256 auctionId, bool giveAway) external;
 
   function getSalePrice(uint256 auctionId) external returns (uint256);
 

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -74,6 +74,11 @@ interface IEditionsAuction {
     address editionContract
   );
 
+  event AuctionEnded(
+    uint256 auctionId,
+    address editionContract
+  );
+
   function createAuction(
     Edition memory edition,
     uint256 startTimestamp,
@@ -96,4 +101,6 @@ interface IEditionsAuction {
   function numberCanMint(uint256 auctionId) external view returns (uint256);
 
   function cancelAuction(uint256 auctionId) external;
+
+  function endAuction(uint256 auctionId) external;
 }

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -11,11 +11,6 @@ struct Edition {
   Implementation implementation;
 }
 
-struct Step {
-  uint256 price;
-  uint256 time;
-}
-
 interface IEditionsAuction {
   struct Auction {
     Edition edition;

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -99,7 +99,3 @@ interface IEditionsAuction {
 
   function endAuction(uint256 auctionId) external;
 }
-
-interface ERC721 {
-  function balanceOf(address owner) external view returns (uint256);
-}

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -25,11 +25,11 @@ interface IEditionsAuction {
     uint256 endPrice;
     uint8 numberOfPriceDrops;
     address creator;
-    Step step;
     bool approved;
     address curator;
     uint256 curatorRoyaltyBPS;
     address auctionCurrency;
+    bool collectorGiveAway;
   }
 
   event EditionPurchased(
@@ -103,4 +103,8 @@ interface IEditionsAuction {
   function cancelAuction(uint256 auctionId) external;
 
   function endAuction(uint256 auctionId) external;
+}
+
+interface ERC721 {
+  function balanceOf(address owner) external view returns (uint256);
 }

--- a/contracts/IEditionsAuction.sol
+++ b/contracts/IEditionsAuction.sol
@@ -69,6 +69,11 @@ interface IEditionsAuction {
     bool approved
   );
 
+  event AuctionCanceled(
+    uint256 auctionId,
+    address editionContract
+  );
+
   function createAuction(
     Edition memory edition,
     uint256 startTimestamp,
@@ -89,4 +94,6 @@ interface IEditionsAuction {
   function purchase(uint256 auctionId, uint256 amount, uint256 seed) external payable returns (uint256);
 
   function numberCanMint(uint256 auctionId) external view returns (uint256);
+
+  function cancelAuction(uint256 auctionId) external;
 }

--- a/contracts/SeededPurchaseHandler.sol
+++ b/contracts/SeededPurchaseHandler.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.6;
 import {ISeededEditionSingleMintable, MintData} from "./editions-nft/ISeededEditionSingleMintable.sol";
 import {IEditionsAuction, Edition, Implementation} from "./IEditionsAuction.sol";
-import {AuctionUtils} from "./Utils.sol";
+import {Utils} from "./Utils.sol";
 
-abstract contract SeededPurchaseHandler is IEditionsAuction, AuctionUtils {
+abstract contract SeededPurchaseHandler is IEditionsAuction, Utils {
   function _handleSeededPurchase(uint256 auctionId, Auction memory auction, uint256 value, uint256 seed) internal returns (uint256){
     // check edtions contract is seeded implementation
     require(

--- a/contracts/SeededPurchaseHandler.sol
+++ b/contracts/SeededPurchaseHandler.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.6;
+import {ISeededEditionSingleMintable, MintData} from "./editions-nft/ISeededEditionSingleMintable.sol";
+import {IEditionsAuction, Edition, Implementation} from "./IEditionsAuction.sol";
+import {AuctionUtils} from "./Utils.sol";
+
+abstract contract SeededPurchaseHandler is IEditionsAuction, AuctionUtils {
+  function _handleSeededPurchase(uint256 auctionId, Auction memory auction, uint256 value, uint256 seed) internal returns (uint256){
+    // check edtions contract is seeded implementation
+    require(
+      auction.edition.implementation == Implementation.seededEdition,
+      "Must be seeded edition contract"
+    );
+
+    // cache
+    uint256 atEditionId;
+
+    if(auction.collectorGiveAway){
+      return  _handleSeededCollectorGiveAway(auctionId, auction, seed);
+    }
+
+    // check value is more or equal to current sale price
+    uint256 salePrice = _getSalePrice(auction);
+    require(value >= salePrice, "Must be more or equal to sale price");
+
+    // if not free handle payment
+    if(salePrice != 0){
+      _handlePurchasePayment(auction, salePrice);
+    }
+
+    atEditionId = _handleSeededMint(auction, seed);
+
+    emit SeededEditionPurchased(
+      auctionId,
+      auction.edition.id,
+      atEditionId - 1,
+      seed,
+      salePrice,
+      msg.sender
+    );
+
+    return atEditionId;
+  }
+
+  function _handleSeededCollectorGiveAway(uint256 auctionId, Auction memory auction, uint256 seed) internal returns (uint256){
+    require(
+      _isCollector(auction.edition.id, msg.sender),
+      "Must be a collector"
+    );
+
+    uint256 atEditionId = _handleSeededMint(auction, seed);
+
+    emit SeededEditionPurchased(
+      auctionId,
+      auction.edition.id,
+      atEditionId - 1,
+      seed,
+      0,
+      msg.sender
+    );
+
+    return atEditionId;
+  }
+
+  function _handleSeededMint(Auction memory auction, uint256 seed) internal returns (uint256) {
+    MintData[] memory toMint = new MintData[](1);
+    toMint[0] = MintData(msg.sender, seed);
+
+    // mint new nft
+    return ISeededEditionSingleMintable(auction.edition.id).mintEditions(toMint);
+  }
+}

--- a/contracts/StandardPurchaseHandler.sol
+++ b/contracts/StandardPurchaseHandler.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.6;
+import {IEditionSingleMintable} from "./editions-nft/IEditionSingleMintable.sol";
+import {IEditionsAuction, Edition, Implementation} from "./IEditionsAuction.sol";
+import {AuctionUtils} from "./Utils.sol";
+
+abstract contract StandardPurchaseHandler is IEditionsAuction, AuctionUtils {
+  function _handleStandardPurchase(uint256 auctionId, Auction memory auction, uint256 value) internal returns (uint256){
+    // check edtions contract is standard implementation
+    require(
+      auction.edition.implementation == Implementation.edition,
+      "Must be edition contract"
+    );
+
+    if(auction.collectorGiveAway){
+      return _handleStandardCollectorGiveAway(auctionId, auction);
+    }
+
+    uint256 salePrice = _getSalePrice(auction);
+    require(value >= salePrice, "Must be more or equal to sale price");
+
+    // if not free carry out purchase
+    if(salePrice != 0){
+      _handlePurchasePayment(auction, salePrice);
+    }
+
+    uint256 atEditionId = _handleStandardMint(auction);
+
+    emit EditionPurchased(
+      auctionId,
+      auction.edition.id,
+      atEditionId - 1,
+      salePrice,
+      msg.sender
+    );
+
+    return atEditionId;
+  }
+
+  function _handleStandardCollectorGiveAway(uint256 auctionId, Auction memory auction) internal returns (uint256){
+    require(
+      _isCollector(auction.edition.id, msg.sender),
+      "Must be a collector"
+    );
+
+    uint256 atEditionId = _handleStandardMint(auction);
+
+    emit EditionPurchased(
+      auctionId,
+      auction.edition.id,
+      atEditionId - 1,
+      0,
+      msg.sender
+    );
+
+    return atEditionId;
+  }
+
+  function _handleStandardMint(Auction memory auction) internal returns (uint256) {
+    address[] memory toMint = new address[](1);
+    toMint[0] = msg.sender;
+
+    // mint new nft
+    return IEditionSingleMintable(auction.edition.id).mintEditions(toMint);
+  }
+}

--- a/contracts/StandardPurchaseHandler.sol
+++ b/contracts/StandardPurchaseHandler.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.6;
 import {IEditionSingleMintable} from "./editions-nft/IEditionSingleMintable.sol";
 import {IEditionsAuction, Edition, Implementation} from "./IEditionsAuction.sol";
-import {AuctionUtils} from "./Utils.sol";
+import {Utils} from "./Utils.sol";
 
-abstract contract StandardPurchaseHandler is IEditionsAuction, AuctionUtils {
+abstract contract StandardPurchaseHandler is IEditionsAuction, Utils {
   function _handleStandardPurchase(uint256 auctionId, Auction memory auction, uint256 value) internal returns (uint256){
     // check edtions contract is standard implementation
     require(

--- a/contracts/Utils.sol
+++ b/contracts/Utils.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.6;
+import {IEditionsAuction} from "./IEditionsAuction.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface ERC721 {
+  function balanceOf(address owner) external view returns (uint256);
+}
+
+abstract contract Utils is IEditionsAuction {
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  function _isCollector(address editionId, address collector) internal view returns (bool) {
+    return (ERC721(editionId).balanceOf(collector) > 0);
+  }
+
+  function _handlePurchasePayment(Auction memory auction, uint256 salePrice) internal{
+    IERC20 token = IERC20(auction.auctionCurrency);
+
+    // NOTE: msg.sender would need to approve this contract with currency before making a purchase
+    // If intergrating with zora v3 the market would hold the funds and handle royalties differently.
+    // through royalties finders, and protocal fees
+    // TODO: respect royalties on NFT contract (v3 intergration could solve this)
+
+    // NOTE: modified from v3 for now. A full intergration would be better if we go that route
+    // https://github.com/ourzora/v3/blob/main/contracts/common/IncomingTransferSupport/V1/IncomingTransferSupportV1.sol
+
+    // We must check the balance that was actually transferred to this contract,
+    // as some tokens impose a transfer fee and would not actually transfer the
+    // full amount to the market, resulting in potentally locked funds
+    uint256 beforeBalance = token.balanceOf(address(this));
+    token.safeTransferFrom(msg.sender, address(this), salePrice);
+    uint256 afterBalance = token.balanceOf(address(this));
+    require(beforeBalance + salePrice == afterBalance, "_handleIncomingTransfer token transfer call did not transfer expected amount");
+
+    // if no curator, add payment to creator
+    if(auction.curator == address(0)){
+      token.safeTransfer(
+        auction.creator,
+        salePrice
+      );
+    }
+
+    // else split payment between curator and creator
+    else {
+      uint256 curatorFee = (salePrice.mul(auction.curatorRoyaltyBPS)).div(10000);
+      token.safeTransfer(
+        auction.curator,
+        curatorFee
+      );
+
+      uint256 creatorFee = salePrice.sub(curatorFee);
+      token.safeTransfer(
+        auction.creator,
+        creatorFee
+      );
+    }
+
+    return;
+  }
+
+  function _getSalePrice(Auction memory auction) internal view returns (uint256) {
+    // return endPrice if auction is over
+    if(block.timestamp > auction.startTimestamp.add(auction.duration)){
+      return auction.endPrice;
+    }
+
+    uint256 stepTime = _calcStepTime(auction);
+
+    // return startPrice if auction hasn't started yet
+    if(block.timestamp <= auction.startTimestamp.add(stepTime)){
+      return auction.startPrice;
+    }
+
+    // calculate price based of block.timestamp
+    uint256 timeSinceStart = block.timestamp.sub(auction.startTimestamp);
+    uint256 dropNum = _floor(timeSinceStart, stepTime).div(stepTime);
+
+    uint256 stepPrice = _calcStepPrice(auction);
+
+    // transalte -1 so endPrice is after auction.duration
+    uint256 price = auction.startPrice.sub(stepPrice.mul(dropNum - 1));
+
+    return _floor(
+      price,
+      _unit10(stepPrice, 2)
+    );
+  }
+
+  function _calcStepPrice(
+    Auction memory auction
+  ) internal pure returns (uint256) {
+      return auction.startPrice.sub(auction.endPrice).div(auction.numberOfPriceDrops);
+  }
+
+  function _calcStepTime(
+    Auction memory auction
+  ) internal pure returns (uint256) {
+      return auction.duration.div(auction.numberOfPriceDrops);
+  }
+
+  /**
+   * @dev floors number to nearest specified unit
+   * @param value number to floor
+   * @param unit number specififying the smallest uint to floor to
+   * @return result number floored to nearest unit
+  */
+  function _floor(uint256 value, uint256 unit) internal pure returns (uint256){
+    uint256 remainder = value.mod(unit);
+    return value - remainder;
+  }
+
+  /** @dev calculates exponent from given value number of digits minus the offset
+   * and returns 10 to the power of the resulting exponent
+   * @param value the number of which the exponent is calculated from
+   * @param exponentOffset the number to offset the resulting exponent
+   * @return result 10 to the power of calculated exponent
+   */
+  function _unit10(uint256 value, uint256 exponentOffset) internal pure returns (uint256){
+    uint256 exponent = _getDigits(value);
+
+    if (exponent == 0) {
+        return 0;
+    }
+
+    if(exponent < exponentOffset || exponentOffset == 0){
+      exponentOffset = 1;
+    }
+
+    return 10**(exponent - exponentOffset);
+  }
+
+   /**
+    * @dev gets number of digits of a number
+    * @param value number to count digits of
+    * @return digits number of digits in value
+    */
+  function _getDigits(uint256 value) internal pure returns (uint256) {
+      if (value == 0) {
+          return 0;
+      }
+      uint256 digits;
+      while (value != 0) {
+          digits++;
+          value /= 10;
+      }
+      return digits;
+  }
+}

--- a/test/EditionsAuctionTest.ts
+++ b/test/EditionsAuctionTest.ts
@@ -657,6 +657,74 @@ describe("EditionsAuction", () => {
     })
   })
 
+  describe("#cancelAuction", async () => {
+    it("should revert if not creator or curator", async () => {
+      await createAuction(creator)
+      await expect(
+        EditionsAuction.connect(collector).cancelAuction(0)
+      ).to.be.revertedWith("Must be creator or curator")
+    })
+
+    it("should revert if approved and auction started", async () => {
+
+      await createAuction(creator)
+      const auction = await EditionsAuction.auctions(0)
+      // mine to past start time
+      await mineToTimestamp(auction.startTimestamp)
+
+      await expect(
+        EditionsAuction.connect(creator).cancelAuction(0)
+      ).to.be.revertedWith("Auction has already started")
+    })
+
+    it("should cancel auction before auction started", async () => {
+      // no curator
+      await createAuction(creator)
+      expect(
+        await EditionsAuction.connect(creator).cancelAuction(0)
+      ).to.emit(EditionsAuction, "AuctionCanceled")
+
+      // curator
+      await createAuction(creator, {
+        curator: await curator.getAddress(),
+        curatorRoyaltyBPS: 1000
+      })
+      expect(
+        await EditionsAuction.connect(curator).cancelAuction(1)
+      ).to.emit(EditionsAuction, "AuctionCanceled")
+    })
+
+    it("should cancel if curator has not approved", async () => {
+      // curator
+      await createAuction(creator, {
+        curator: await curator.getAddress(),
+        curatorRoyaltyBPS: 1000
+      })
+
+      const curatedAuction = await EditionsAuction.auctions(0)
+      // mine to start time
+      await mineToTimestamp(curatedAuction.startTimestamp.add(curatedAuction.step.time))
+
+      expect(
+        await EditionsAuction.connect(creator).cancelAuction(0)
+      ).to.emit(EditionsAuction, "AuctionCanceled")
+    })
+
+    it("should emit AuctionCanceled event", async () => {
+      await createAuction(creator)
+      const auction = await EditionsAuction.auctions(0)
+
+      expect(
+        await EditionsAuction.connect(creator).cancelAuction(0)
+      ).to.emit(
+        EditionsAuction, "AuctionCanceled"
+      ).withArgs(
+        0,
+        SingleEdition.address
+      )
+    })
+  })
+
   describe("Internals", () => {
     let ExposedInternals: ExposedInternals
     beforeEach(async () => {


### PR DESCRIPTION
resolves #13

adds options to cancel and end auctions as well as trigger a collectors give away.

- [x] cancel auction
- [x] end auction
- [x] trigger collectors give away

These changes lead to some refactoring of the code
- step price and time are no longer stored on-chain but calculated when needed
- purchase implementations refactored into two separate abstract contracts `StandardPurchaseHandler` and `SeededPurchaseHandler` of which are inherited by `EditionsAuction`
- moved utility functions that are shared across contracts to `Utils.sol`